### PR TITLE
Update mainnet fork tests to reflect that DIP 3 + 4 + 5 have passed

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,7 +8,7 @@ import {
 const configSchema = {
   DEPLOYMENT_LOGS: parseBoolean({ default: null }),
   FORK_MAINNET: parseBoolean({ default: false }),
-  FORK_BLOCK_NUMBER: parseInteger({ default: 13592927 }),
+  FORK_BLOCK_NUMBER: parseInteger({ default: 13678600 }),
   HARDHAT_SIMULATE_AFFECTED_STAKERS: parseInteger({ default: 3 }),
   OVERRIDE_DEPLOYER_ADDRESS: parseString({ default: null }),
   PROMPT_AUTO_YES: parseBoolean({ default: false }),

--- a/test/helpers/describe-contract.ts
+++ b/test/helpers/describe-contract.ts
@@ -42,15 +42,15 @@ export function describeContractForNetwork(
  * @notice Used for running tests on the Hardhat network (excluding mainnet forks). The tests
  *  will be skipped if on a non-Hardhat network or mainnet fork.
  *
- *  IMPORTANT: This method is different than `describeContract` because it does _not_ revert snapshots
- *  after each test (only after all tests have run). This is useful if the tests persist state into nested
- *  `describe` blocks.
+ *  IMPORTANT: This method is different than `describeContractHardhatRevertBeforeEach` because it does _not_
+ *  revert snapshots after each test (only after all tests have run). This is useful if you want the contracts
+ *  to persist state into nested `describe` blocks.
  *
  * @param  name   The name of the test.
  * @param  init   The function to run before running the tests.
  * @param  tests  The tests to run.
  */
-export function describeContractHardhat(
+export function describeContractHardhatRevertBefore(
   name: string,
   init: (ctx: TestContext) => void | Promise<void>,
   tests: (ctx: TestContext) => void,
@@ -156,5 +156,30 @@ async function maybeEvmReset(
 ): Promise<void> {
   if (config.isHardhat()) {
     await evmReset(id);
+  }
+}
+
+/**
+ * @notice Used for running tests on the Hardhat network (excluding mainnet forks). The tests
+ *  will be skipped if on a non-Hardhat network or mainnet fork.
+ *
+ *  IMPORTANT: This method is different than `describeContractHardhatRevertBefore` because it does _not_
+ *  revert snapshots after each test (only after all tests have run). This is useful if you don't want the
+ *  the contracts to persist state into nested `describe` blocks.
+ *
+ * @param  name   The name of the test.
+ * @param  init   The function to run before running the tests.
+ * @param  tests  The tests to run.
+ */
+export function describeContractHardhatRevertBeforeEach(
+  name: string,
+  init: (ctx: TestContext) => void | Promise<void>,
+  tests: (ctx: TestContext) => void,
+): void {
+  if (config.FORK_MAINNET) {
+    // Skip tests that do not run on mainnet forks when forking mainnet.
+    describe.skip(name, () => {});
+  } else {
+    describeContract(name, init, tests);
   }
 }

--- a/test/helpers/describe-contract.ts
+++ b/test/helpers/describe-contract.ts
@@ -163,9 +163,9 @@ async function maybeEvmReset(
  * @notice Used for running tests on the Hardhat network (excluding mainnet forks). The tests
  *  will be skipped if on a non-Hardhat network or mainnet fork.
  *
- *  IMPORTANT: This method is different than `describeContractHardhatRevertBefore` because it does _not_
- *  revert snapshots after each test (only after all tests have run). This is useful if you don't want the
- *  the contracts to persist state into nested `describe` blocks.
+ *  IMPORTANT: This method is different than `describeContractHardhatRevertBefore` because it _does_
+ *  revert snapshots after each test. This is useful if you don't want the contracts to persist state
+ *  into nested `describe` blocks.
  *
  * @param  name   The name of the test.
  * @param  init   The function to run before running the tests.

--- a/test/helpers/get-deployed-contracts-for-test.ts
+++ b/test/helpers/get-deployed-contracts-for-test.ts
@@ -44,10 +44,14 @@ async function getDeployedContractsForTest(): Promise<AllDeployedContracts> {
     deployedContracts = await getAllContracts();
   } else {
     deployedContracts = await deployContractsForTest();
+
+    // Put proposals that have already been executed on mainnet here.
+    await executeSafetyModuleRecoveryProposalsForTest(deployedContracts);
+    await executeStarkProxyProposalForTest(deployedContracts);
   }
 
-  await executeSafetyModuleRecoveryProposalsForTest(deployedContracts);
-  await executeStarkProxyProposalForTest(deployedContracts);
+  // Put proposals that have not been executed on mainnet here.
+
   await configureForTest(deployedContracts);
   return deployedContracts;
 }

--- a/test/helpers/get-deployed-contracts-for-test.ts
+++ b/test/helpers/get-deployed-contracts-for-test.ts
@@ -45,12 +45,15 @@ async function getDeployedContractsForTest(): Promise<AllDeployedContracts> {
   } else {
     deployedContracts = await deployContractsForTest();
 
-    // Put proposals that have already been executed on mainnet here.
+    // Execute the proposals which have already been executed on mainnet.
+    //
+    // The proposals will be executed when running on a local test network,
+    // but will not be executed when running on a mainnet fork.
     await executeSafetyModuleRecoveryProposalsForTest(deployedContracts);
     await executeStarkProxyProposalForTest(deployedContracts);
   }
 
-  // Put proposals that have not been executed on mainnet here.
+  // Execute the proposals which have not yet been executed on mainnet.
 
   await configureForTest(deployedContracts);
   return deployedContracts;

--- a/test/safety-module/events.spec.ts
+++ b/test/safety-module/events.spec.ts
@@ -8,7 +8,7 @@ import { ZERO_ADDRESS } from '../../src/lib/constants';
 import { getRole } from '../../src/lib/util';
 import { DelegationType, Role } from '../../src/types';
 import { SafetyModuleV2 } from '../../types';
-import { TestContext, describeContract } from '../helpers/describe-contract';
+import { TestContext, describeContractHardhatRevertBeforeEach } from '../helpers/describe-contract';
 import { getAffectedStakersForTest } from '../helpers/get-affected-stakers-for-test';
 
 type EventName = keyof SafetyModuleV2['filters'];
@@ -19,7 +19,7 @@ function init() {
   testStakers = getAffectedStakersForTest();
 }
 
-describeContract('SafetyModuleV2 initial emitted events', init, (ctx: TestContext) => {
+describeContractHardhatRevertBeforeEach('SafetyModuleV2 initial emitted events', init, (ctx: TestContext) => {
 
   it('Events that were not emitted', async () => {
     const eventNames: EventName[] = [

--- a/test/safety-module/sm1-erc20.spec.ts
+++ b/test/safety-module/sm1-erc20.spec.ts
@@ -8,7 +8,7 @@ import {
   MockSafetyModuleSubclass,
   MockSafetyModuleSubclass__factory,
 } from '../../types';
-import { describeContract, TestContext } from '../helpers/describe-contract';
+import { describeContractHardhatRevertBeforeEach, TestContext } from '../helpers/describe-contract';
 import { latestBlockTimestamp } from '../helpers/evm';
 import { StakingHelper } from '../helpers/staking-helper';
 
@@ -57,7 +57,7 @@ async function init(ctx: TestContext) {
   await contract.mintAndApprove(staker2, stakerInitialBalance2);
 }
 
-describeContract('SM1Erc20', init, (ctx: TestContext) => {
+describeContractHardhatRevertBeforeEach('SM1Erc20', init, (ctx: TestContext) => {
 
   before(() => {
     contract.saveSnapshot('main');

--- a/test/safety-module/sm1-operators.spec.ts
+++ b/test/safety-module/sm1-operators.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 
 import { Role } from '../../src/types';
 import { SafetyModuleV1 } from '../../types';
-import { describeContract, TestContext } from '../helpers/describe-contract';
+import { describeContractHardhatRevertBeforeEach, TestContext } from '../helpers/describe-contract';
 import { StakingHelper } from '../helpers/staking-helper';
 
 const stakerInitialBalance: number = 1_000_000;
@@ -40,7 +40,7 @@ async function init(ctx: TestContext) {
   await Promise.all(stakers.map((s) => contract.mintAndApprove(s, stakerInitialBalance)));
 }
 
-describeContract('SM1Operator', init, (ctx: TestContext) => {
+describeContractHardhatRevertBeforeEach('SM1Operator', init, (ctx: TestContext) => {
 
   before(() => {
     contract.saveSnapshot('main');

--- a/test/safety-module/sm1-slashing.spec.ts
+++ b/test/safety-module/sm1-slashing.spec.ts
@@ -11,7 +11,7 @@ import {
   SafetyModuleV1,
   SafetyModuleV11__factory,
 } from '../../types';
-import { describeContract, TestContext } from '../helpers/describe-contract';
+import { describeContractHardhatRevertBeforeEach, TestContext } from '../helpers/describe-contract';
 import {
   advanceBlock,
   increaseTimeAndMine,
@@ -53,7 +53,7 @@ async function init(ctx: TestContext) {
   await contract.setRewardsPerSecond(0);
 }
 
-describeContract('SM1Slashing', init, (ctx: TestContext) => {
+describeContractHardhatRevertBeforeEach('SM1Slashing', init, (ctx: TestContext) => {
 
   before(() => {
     contract.saveSnapshot('main');

--- a/test/safety-module/sm1-staking.spec.ts
+++ b/test/safety-module/sm1-staking.spec.ts
@@ -1,6 +1,3 @@
-import { AFFECTED_STAKERS } from '../../src/lib/affected-stakers';
-import { impersonateAccount } from '../../src/migrations/helpers/impersonate-account';
-import { getAffectedStakersForTest } from '../helpers/get-affected-stakers-for-test';
 import { addStakingTestCases } from './test-cases/staking-test-cases';
 
 describe('SM1Staking with new stakers', () => {
@@ -10,15 +7,4 @@ describe('SM1Staking with new stakers', () => {
       ctx.users[1],
     ],
   );
-});
-
-describe('SM1Staking with stakers affected by the Safety Module bug', () => {
-  if (getAffectedStakersForTest().length >= 2) {
-    addStakingTestCases(
-      async () => [
-        await impersonateAccount(AFFECTED_STAKERS[0]),
-        await impersonateAccount(AFFECTED_STAKERS[1]),
-      ],
-    );
-  }
 });

--- a/test/safety-module/sm1-staking.spec.ts
+++ b/test/safety-module/sm1-staking.spec.ts
@@ -1,3 +1,6 @@
+import { AFFECTED_STAKERS } from '../../src/lib/affected-stakers';
+import { impersonateAccount } from '../../src/migrations/helpers/impersonate-account';
+import { getAffectedStakersForTest } from '../helpers/get-affected-stakers-for-test';
 import { addStakingTestCases } from './test-cases/staking-test-cases';
 
 describe('SM1Staking with new stakers', () => {
@@ -7,4 +10,15 @@ describe('SM1Staking with new stakers', () => {
       ctx.users[1],
     ],
   );
+});
+
+describe('SM1Staking with stakers affected by the Safety Module bug', () => {
+  if (getAffectedStakersForTest().length >= 2) {
+    addStakingTestCases(
+      async () => [
+        await impersonateAccount(AFFECTED_STAKERS[0]),
+        await impersonateAccount(AFFECTED_STAKERS[1]),
+      ],
+    );
+  }
 });

--- a/test/safety-module/sm2-recovery.spec.ts
+++ b/test/safety-module/sm2-recovery.spec.ts
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import { AFFECTED_STAKERS, getOwedAmount } from '../../src/lib/affected-stakers';
 import { fundAccount, impersonateAccount, IMPERSONATED_ACCOUNT_STIPEND } from '../../src/migrations/helpers/impersonate-account';
 import { SM2Recovery } from '../../types';
-import { describeContract, TestContext } from '../helpers/describe-contract';
+import { describeContractHardhatRevertBeforeEach, TestContext } from '../helpers/describe-contract';
 import { getAffectedStakersForTest } from '../helpers/get-affected-stakers-for-test';
 
 const EXPECTED_TOTAL_OWED = '173204761823871505252385';
@@ -21,7 +21,7 @@ function init(ctx: TestContext) {
   contract = ctx.safetyModuleRecovery;
 }
 
-describeContract('SM2Recovery', init, (ctx: TestContext) => {
+describeContractHardhatRevertBeforeEach('SM2Recovery', init, (ctx: TestContext) => {
 
   it('Proxy admin is owned by the short timelock', async () => {
     const owner = await ctx.safetyModuleRecoveryProxyAdmin.owner();

--- a/test/safety-module/state.spec.ts
+++ b/test/safety-module/state.spec.ts
@@ -5,7 +5,7 @@ import { BigNumber } from 'ethers';
 import { SM_ROLE_HASHES } from '../../src/lib/constants';
 import { getRole } from '../../src/lib/util';
 import { Role } from '../../src/types';
-import { TestContext, describeContract } from '../helpers/describe-contract';
+import { TestContext, describeContractHardhatRevertBeforeEach } from '../helpers/describe-contract';
 
 let staker: SignerWithAddress;
 
@@ -13,7 +13,7 @@ function init(ctx: TestContext) {
   [staker] = ctx.users;
 }
 
-describeContract('SafetyModuleV2 initial state', init, (ctx: TestContext) => {
+describeContractHardhatRevertBeforeEach('SafetyModuleV2 initial state', init, (ctx: TestContext) => {
 
   describe('Proxy admin', () => {
 

--- a/test/safety-module/storage-slots.spec.ts
+++ b/test/safety-module/storage-slots.spec.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import { SM_EXCHANGE_RATE_BASE } from '../../src/lib/constants';
 import { asBytes32, asUintHex, concatHex } from '../../src/lib/hex';
-import { TestContext, describeContract } from '../helpers/describe-contract';
+import { TestContext, describeContractHardhatRevertBeforeEach } from '../helpers/describe-contract';
 import { getAffectedStakersForTest } from '../helpers/get-affected-stakers-for-test';
 import hre from '../hre';
 
@@ -15,7 +15,7 @@ function init() {
   testStakers = getAffectedStakersForTest();
 }
 
-describeContract('SafetyModuleV2 initial storage slots', init, (ctx: TestContext) => {
+describeContractHardhatRevertBeforeEach('SafetyModuleV2 initial storage slots', init, (ctx: TestContext) => {
 
   it('0–49: AccessControlUpgradeable', async () => {
     await expectZeroes(_.range(0, 50));

--- a/test/safety-module/test-cases/snapshots-test-cases.ts
+++ b/test/safety-module/test-cases/snapshots-test-cases.ts
@@ -7,7 +7,7 @@ import { BigNumber, BigNumberish } from 'ethers';
 
 import { DelegationType } from '../../../src/types';
 import { SafetyModuleV1 } from '../../../types';
-import { describeContract, TestContext } from '../../helpers/describe-contract';
+import { describeContractHardhatRevertBeforeEach, TestContext } from '../../helpers/describe-contract';
 import {
   advanceBlock,
   increaseTimeAndMine,
@@ -41,7 +41,7 @@ export function addSnapshotsTestCases(
     staker1InitialTokenBalance = await ctx.dydxToken.balanceOf(staker1.address);
   }
 
-  describeContract('Safety Module snapshots - getPowerAtBlock()', init, (ctx: TestContext) => {
+  describeContractHardhatRevertBeforeEach('Safety Module snapshots - getPowerAtBlock()', init, (ctx: TestContext) => {
 
     it('Governance power is initially zero', async () => {
       await expectPowerAtBlock(staker1, 0, 0);

--- a/test/safety-module/test-cases/staking-test-cases.ts
+++ b/test/safety-module/test-cases/staking-test-cases.ts
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 import { ZERO_ADDRESS } from '../../../src/lib/constants';
 import { deployUpgradeable } from '../../../src/migrations/helpers/deploy-upgradeable';
 import { SafetyModuleV1, SafetyModuleV11__factory } from '../../../types';
-import { describeContract, TestContext } from '../../helpers/describe-contract';
+import { describeContractHardhatRevertBeforeEach, TestContext } from '../../helpers/describe-contract';
 import {
   incrementTimeToTimestamp,
   latestBlockTimestamp,
@@ -79,7 +79,7 @@ export function addStakingTestCases(
     await contract.setRewardsPerSecond(0);
   }
 
-  describeContract('SM1Staking', init, (ctx: TestContext) => {
+  describeContractHardhatRevertBeforeEach('SM1Staking', init, (ctx: TestContext) => {
 
     before(() => {
       contract.saveSnapshot('main');

--- a/test/stark-proxy/sp1-borrowing.spec.ts
+++ b/test/stark-proxy/sp1-borrowing.spec.ts
@@ -9,7 +9,7 @@ import { IERC20 } from '../../types/IERC20';
 import { IStarkPerpetual } from '../../types/IStarkPerpetual';
 import { LiquidityStakingV1 } from '../../types/LiquidityStakingV1';
 import { StarkProxyV1 } from '../../types/StarkProxyV1';
-import { describeContractHardhat, TestContext } from '../helpers/describe-contract';
+import { describeContractHardhatRevertBefore, TestContext } from '../helpers/describe-contract';
 import { increaseTime, increaseTimeAndMine, loadSnapshot, saveSnapshot } from '../helpers/evm';
 import { findAddressWithRole } from '../helpers/get-address-with-role';
 import { StakingHelper } from '../helpers/staking-helper';
@@ -91,7 +91,7 @@ async function init(ctx: TestContext) {
   await saveSnapshot(snapshots, fundsStakedSnapshot, contract);
 }
 
-describeContractHardhat('SP1Borrowing', init, () => {
+describeContractHardhatRevertBefore('SP1Borrowing', init, () => {
 
   describe('After stake is deposited and allocations are set', () => {
     before(async () => {

--- a/test/stark-proxy/sp2-exchange.spec.ts
+++ b/test/stark-proxy/sp2-exchange.spec.ts
@@ -9,7 +9,7 @@ import { IERC20 } from '../../types/IERC20';
 import { IStarkPerpetual } from '../../types/IStarkPerpetual';
 import { LiquidityStakingV1 } from '../../types/LiquidityStakingV1';
 import { StarkProxyV1 } from '../../types/StarkProxyV1';
-import { describeContractHardhat, TestContext } from '../helpers/describe-contract';
+import { describeContractHardhatRevertBefore, TestContext } from '../helpers/describe-contract';
 import { evmReset, evmSnapshot } from '../helpers/evm';
 import { findAddressWithRole } from '../helpers/get-address-with-role';
 import { StakingHelper } from '../helpers/staking-helper';
@@ -98,7 +98,7 @@ async function init(ctx: TestContext) {
   contract.saveSnapshot(borrowerHasBorrowed);
 }
 
-describeContractHardhat('SP2Exchange', init, () => {
+describeContractHardhatRevertBefore('SP2Exchange', init, () => {
   describe('interacting with the exchange', () => {
     const starkKey = 123;
     let postInitSnapshotId: string;

--- a/test/stark-proxy/sp2-owner.spec.ts
+++ b/test/stark-proxy/sp2-owner.spec.ts
@@ -12,7 +12,7 @@ import { IFreezableStarkPerpetual } from '../../types/IFreezableStarkPerpetual';
 import { IStarkPerpetual } from '../../types/IStarkPerpetual';
 import { StarkProxyV1 } from '../../types/StarkProxyV1';
 import { StarkProxyV2 } from '../../types/StarkProxyV2';
-import { TestContext, describeContract, describeContractForNetwork } from '../helpers/describe-contract';
+import { TestContext, describeContractForNetwork, describeContractHardhatRevertBeforeEach } from '../helpers/describe-contract';
 import { increaseTimeAndMine, incrementTimeToTimestamp, latestBlockTimestamp } from '../helpers/evm';
 import { findAddressWithRole } from '../helpers/get-address-with-role';
 
@@ -28,7 +28,7 @@ async function init(ctx: TestContext): Promise<void> {
   borrowerStarkProxy = new StarkProxyV2__factory(borrower).attach(ctx.starkProxies[0].address);
 }
 
-describeContract('SP2Owner', init, (ctx: TestContext) => {
+describeContractHardhatRevertBeforeEach('SP2Owner', init, (ctx: TestContext) => {
 
   describeContractForNetwork(
     'SP2Owner Hardhat Tests',

--- a/test/stark-proxy/sp2-withdrawals.spec.ts
+++ b/test/stark-proxy/sp2-withdrawals.spec.ts
@@ -15,7 +15,7 @@ import { LiquidityStakingV1 } from '../../types/LiquidityStakingV1';
 import { MerkleDistributorV1 } from '../../types/MerkleDistributorV1';
 import { MockRewardsOracle } from '../../types/MockRewardsOracle';
 import { StarkProxyV1 } from '../../types/StarkProxyV1';
-import { describeContractHardhat, TestContext } from '../helpers/describe-contract';
+import { describeContractHardhatRevertBefore, TestContext } from '../helpers/describe-contract';
 import { incrementTimeToTimestamp, latestBlockTimestamp, loadSnapshot, saveSnapshot } from '../helpers/evm';
 import { findAddressWithRole } from '../helpers/get-address-with-role';
 import { StakingHelper } from '../helpers/staking-helper';
@@ -91,7 +91,7 @@ async function init(ctx: TestContext) {
   await saveSnapshot(snapshots, fundsStakedSnapshot, contract);
 }
 
-describeContractHardhat('SP2Withdrawals', init, (ctx: TestContext) => {
+describeContractHardhatRevertBefore('SP2Withdrawals', init, (ctx: TestContext) => {
   describe('Borrower, after borrowing funds', () => {
 
     before(async () => {


### PR DESCRIPTION
Some mainnet fork tests are failing now that DIP 3 + 4 + 5 have passed. Update tests that assume a certain contract state to only run on Hardhat.