### PR TITLE
StarkProxyV3, script to deploy and update owner role [BAC-2267]

### DIFF
--- a/contracts/stark-proxy/v3/StarkProxyV3.sol
+++ b/contracts/stark-proxy/v3/StarkProxyV3.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.7.5;
+pragma abicoder v2;
+
+import { IERC20 } from '../../interfaces/IERC20.sol';
+import { ILiquidityStakingV1 } from '../../interfaces/ILiquidityStakingV1.sol';
+import { IMerkleDistributorV1 } from '../../interfaces/IMerkleDistributorV1.sol';
+import { IStarkPerpetual } from '../../interfaces/IStarkPerpetual.sol';
+import { SafeERC20 } from '../../dependencies/open-zeppelin/SafeERC20.sol';
+import { SP2Withdrawals } from '../v2/impl/SP2Withdrawals.sol';
+import { SP1Getters } from '../v1/impl/SP1Getters.sol';
+import { SP2Guardian } from '../v2/impl/SP2Guardian.sol';
+import { SP3Owner } from './impl/SP3Owner.sol';
+
+/**
+ * @title StarkProxyV3
+ * @author dYdX
+ *
+ * @notice Proxy contract allowing a LiquidityStaking borrower to use borrowed funds (as well as
+ *  their own funds, if desired) on the dYdX L2 exchange. Restrictions are put in place to
+ *  prevent borrowed funds being used outside the exchange. Furthermore, a guardian address is
+ *  specified which has the ability to restrict borrows and make repayments.
+ *
+ *  Owner actions may be delegated to various roles as defined in SP1Roles. Other actions are
+ *  available to guardian roles, to be nominated by dYdX governance.
+ */
+contract StarkProxyV3 is
+  SP2Guardian,
+  SP3Owner,
+  SP2Withdrawals,
+  SP1Getters
+{
+  using SafeERC20 for IERC20;
+
+  // ============ Constructor ============
+
+  constructor(
+    ILiquidityStakingV1 liquidityStaking,
+    IStarkPerpetual starkPerpetual,
+    IERC20 token,
+    IMerkleDistributorV1 merkleDistributor
+  )
+    SP2Guardian(liquidityStaking, starkPerpetual, token)
+    SP2Withdrawals(merkleDistributor)
+  {}
+
+  // ============ External Functions ============
+
+  function initialize()
+    external
+    initializer
+  {}
+
+  // ============ Internal Functions ============
+
+  /**
+   * @dev Returns the revision of the implementation contract.
+   *
+   * @return The revision number.
+   */
+  function getRevision()
+    internal
+    pure
+    override
+    returns (uint256)
+  {
+    return 3;
+  }
+}

--- a/contracts/stark-proxy/v3/impl/SP3Owner.sol
+++ b/contracts/stark-proxy/v3/impl/SP3Owner.sol
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.7.5;
+pragma abicoder v2;
+
+import { SafeERC20 } from '../../../dependencies/open-zeppelin/SafeERC20.sol';
+import { SafeMath } from '../../../dependencies/open-zeppelin/SafeMath.sol';
+import { IERC20 } from '../../../interfaces/IERC20.sol';
+import { IStarkPerpetual } from '../../../interfaces/IStarkPerpetual.sol';
+import { SP1Borrowing } from '../../v1/impl/SP1Borrowing.sol';
+import { SP2Exchange } from '../../v2/impl/SP2Exchange.sol';
+import { IGovernancePowerDelegationERC20 } from '../../../interfaces/IGovernancePowerDelegationERC20.sol';
+
+/**
+ * @title SP2Owner
+ * @author dYdX
+ *
+ * @dev Actions which may be called only by OWNER_ROLE. These include actions with a larger amount
+ *  of control over the funds held by the contract.
+ */
+abstract contract SP3Owner is
+  SP1Borrowing,
+  SP2Exchange
+{
+  using SafeERC20 for IERC20;
+  using SafeMath for uint256;
+
+  // ============ Constants ============
+
+  /// @notice Time that must elapse before a queued forced trade request can be submitted.
+  uint256 public constant FORCED_TRADE_WAITING_PERIOD = 7 days;
+
+  /// @notice Max time that may elapse after the waiting period before a queued forced trade
+  ///  request expires.
+  uint256 public constant FORCED_TRADE_GRACE_PERIOD = 7 days;
+
+  /// @notice Address of the DYDX Token Smart Contract.
+  address public constant DYDX_ADDRESS = 0x92D6C1e31e14520e676a687F0a93788B716BEff5;
+
+  /// @notice Address of the Staked DYDX Token Smart Contract.
+  address public constant STAKED_DYDX_ADDRESS = 0x65f7BA4Ec257AF7c55fd5854E5f6356bBd0fb8EC;
+
+  // ============ Events ============
+
+  event UpdatedStarkKey(
+    uint256 starkKey,
+    bool isAllowed
+  );
+
+  event UpdatedExternalRecipient(
+    address recipient,
+    bool isAllowed
+  );
+
+  event QueuedForcedTradeRequest(
+    uint256[12] args,
+    bytes32 argsHash
+  );
+
+  // ============ External Functions ============
+
+  /**
+   * @notice Allow exchange functions to be called for a particular STARK key.
+   *
+   *  Will revert if the STARK key is not registered to this contract's address on the
+   *  StarkPerpetual contract.
+   *
+   * @param  starkKey  The STARK key to allow.
+   */
+  function allowStarkKey(
+    uint256 starkKey
+  )
+    external
+    nonReentrant
+    onlyRole(OWNER_ROLE)
+  {
+    // This will revert with 'USER_UNREGISTERED' if the STARK key was not registered.
+    address ethKey = STARK_PERPETUAL.getEthKey(starkKey);
+
+    // Require the STARK key to be registered to this contract before we allow it to be used.
+    require(ethKey == address(this), 'SP2Owner: STARK key not registered to this contract');
+
+    require(!_ALLOWED_STARK_KEYS_[starkKey], 'SP2Owner: STARK key already allowed');
+    _ALLOWED_STARK_KEYS_[starkKey] = true;
+    emit UpdatedStarkKey(starkKey, true);
+  }
+
+  /**
+   * @notice Remove a STARK key from the allowed list.
+   *
+   * @param  starkKey  The STARK key to disallow.
+   */
+  function disallowStarkKey(
+    uint256 starkKey
+  )
+    external
+    nonReentrant
+    onlyRole(OWNER_ROLE)
+  {
+    require(_ALLOWED_STARK_KEYS_[starkKey], 'SP2Owner: STARK key already disallowed');
+    _ALLOWED_STARK_KEYS_[starkKey] = false;
+    emit UpdatedStarkKey(starkKey, false);
+  }
+
+  /**
+   * @notice Allow withdrawals of excess funds to be made to a particular recipient.
+   *
+   * @param  recipient  The recipient to allow.
+   */
+  function allowExternalRecipient(
+    address recipient
+  )
+    external
+    nonReentrant
+    onlyRole(OWNER_ROLE)
+  {
+    require(!_ALLOWED_RECIPIENTS_[recipient], 'SP2Owner: Recipient already allowed');
+    _ALLOWED_RECIPIENTS_[recipient] = true;
+    emit UpdatedExternalRecipient(recipient, true);
+  }
+
+  /**
+   * @notice Remove a recipient from the allowed list.
+   *
+   * @param  recipient  The recipient to disallow.
+   */
+  function disallowExternalRecipient(
+    address recipient
+  )
+    external
+    nonReentrant
+    onlyRole(OWNER_ROLE)
+  {
+    require(_ALLOWED_RECIPIENTS_[recipient], 'SP2Owner: Recipient already disallowed');
+    _ALLOWED_RECIPIENTS_[recipient] = false;
+    emit UpdatedExternalRecipient(recipient, false);
+  }
+
+  /**
+   * @notice Set ERC20 token allowance for the exchange contract.
+   *
+   * @param  token   The ERC20 token to set the allowance for.
+   * @param  amount  The new allowance amount.
+   */
+  function setExchangeContractAllowance(
+    address token,
+    uint256 amount
+  )
+    external
+    nonReentrant
+    onlyRole(OWNER_ROLE)
+  {
+    // SafeERC20 safeApprove requires setting to zero first.
+    IERC20(token).safeApprove(address(STARK_PERPETUAL), 0);
+    IERC20(token).safeApprove(address(STARK_PERPETUAL), amount);
+  }
+
+  /**
+   * @notice Set ERC20 token allowance for the staking contract.
+   *
+   * @param  token   The ERC20 token to set the allowance for.
+   * @param  amount  The new allowance amount.
+   */
+  function setStakingContractAllowance(
+    address token,
+    uint256 amount
+  )
+    external
+    nonReentrant
+    onlyRole(OWNER_ROLE)
+  {
+    // SafeERC20 safeApprove requires setting to zero first.
+    IERC20(token).safeApprove(address(LIQUIDITY_STAKING), 0);
+    IERC20(token).safeApprove(address(LIQUIDITY_STAKING), amount);
+  }
+
+  /**
+   * @notice Request a forced withdrawal from the exchange.
+   *
+   * @param  starkKey         The STARK key of the account. Must be authorized by OWNER_ROLE.
+   * @param  vaultId          The exchange position ID for the account to deposit to.
+   * @param  quantizedAmount  The withdrawal amount denominated in the exchange base units.
+   * @param  premiumCost      Whether to pay a higher fee for faster inclusion in certain scenarios.
+   */
+  function forcedWithdrawalRequest(
+    uint256 starkKey,
+    uint256 vaultId,
+    uint256 quantizedAmount,
+    bool premiumCost
+  )
+    external
+    nonReentrant
+    onlyRole(OWNER_ROLE)
+    onlyAllowedKey(starkKey)
+  {
+    _forcedWithdrawalRequest(starkKey, vaultId, quantizedAmount, premiumCost, false);
+  }
+
+  /**
+   * @notice Queue a forced trade request to be submitted after the waiting period.
+   *
+   * @param  args  Arguments for the forced trade request.
+   */
+  function queueForcedTradeRequest(
+    uint256[12] calldata args
+  )
+    external
+    nonReentrant
+    onlyRole(OWNER_ROLE)
+  {
+    bytes32 argsHash = keccak256(abi.encodePacked(args));
+    _QUEUED_FORCED_TRADE_TIMESTAMPS_[argsHash] = block.timestamp;
+    emit QueuedForcedTradeRequest(args, argsHash);
+  }
+
+  /**
+   * @notice Submit a forced trade request that was previously queued.
+   *
+   * @param  args       Arguments for the forced trade request.
+   * @param  signature  The signature of the counterparty to the trade.
+   */
+  function forcedTradeRequest(
+    uint256[12] calldata args,
+    bytes calldata signature
+  )
+    external
+    nonReentrant
+    onlyRole(OWNER_ROLE)
+    onlyAllowedKey(args[0]) // starkKeyA
+  {
+    bytes32 argsHash = keccak256(abi.encodePacked(args));
+    uint256 timestamp = _QUEUED_FORCED_TRADE_TIMESTAMPS_[argsHash];
+    require(
+      timestamp != 0,
+      'SP2Owner: Forced trade not queued or was vetoed'
+    );
+    uint256 elapsed = block.timestamp.sub(timestamp);
+    require(
+      elapsed >= FORCED_TRADE_WAITING_PERIOD,
+      'SP2Owner: Waiting period has not elapsed for forced trade'
+    );
+    require(
+      elapsed <= FORCED_TRADE_WAITING_PERIOD.add(FORCED_TRADE_GRACE_PERIOD),
+      'SP2Owner: Grace period has elapsed for forced trade'
+    );
+    _QUEUED_FORCED_TRADE_TIMESTAMPS_[argsHash] = 0;
+    _forcedTradeRequest(args, signature, false);
+  }
+
+  /**
+   * @notice Request to cancel a pending deposit to the exchange.
+   *
+   * @param  starkKey   The STARK key of the account. Must be authorized by OWNER_ROLE.
+   * @param  assetType  The exchange asset ID for the deposit.
+   * @param  vaultId    The exchange position ID for the deposit.
+   */
+  function depositCancel(
+    uint256 starkKey,
+    uint256 assetType,
+    uint256 vaultId
+  )
+    external
+    nonReentrant
+    onlyRole(OWNER_ROLE)
+    onlyAllowedKey(starkKey)
+  {
+    _depositCancel(starkKey, assetType, vaultId, false);
+  }
+
+  /**
+   * @notice Reclaim a canceled pending deposit to the exchange. Requires that `depositCancel`
+   *  was previously called.
+   *
+   * @param  starkKey   The STARK key of the account. Must be authorized by OWNER_ROLE.
+   * @param  assetType  The exchange asset ID for the deposit.
+   * @param  vaultId    The exchange position ID for the deposit.
+   */
+  function depositReclaim(
+    uint256 starkKey,
+    uint256 assetType,
+    uint256 vaultId
+  )
+    external
+    nonReentrant
+    onlyRole(OWNER_ROLE)
+    onlyAllowedKey(starkKey)
+  {
+    _depositReclaim(starkKey, assetType, vaultId, false);
+  }
+
+  /**
+   * @notice Delegates governance power of DYDX or stakedDYDX to a delegatee.
+   *
+   * @param  token     The address of the token to delegate. Must be DYDX_ADDRESS or STAKED_DYDX_ADDRESS.
+   * @param  delegatee The address to delegate to.
+   */
+  function delegate(
+    address token,
+    address delegatee
+  )
+    external
+    nonReentrant
+    onlyRole(OWNER_ROLE)
+  {
+    require(
+      token == DYDX_ADDRESS ||
+      token == STAKED_DYDX_ADDRESS,
+      'tokenAddress is not DYDX or stakedDYDX'
+    );
+    IGovernancePowerDelegationERC20(token).delegate(delegatee);
+  }
+
+  /**
+   * @notice Delegates a specific governance power of DYDX or stakedDYDX to a delegatee.
+   *
+   * @param  token           The address of the token to delegate. Must be DYDX_ADDRESS or STAKED_DYDX_ADDRESS.
+   * @param  delegatee       The address to delegate to.
+   * @param  delegationType  The type of delegation (VOTING_POWER, PROPOSITION_POWER).
+   */
+  function delegateByType(
+    address token,
+    address delegatee,
+    IGovernancePowerDelegationERC20.DelegationType delegationType
+  )
+    external
+    nonReentrant
+    onlyRole(OWNER_ROLE)
+  {
+    require(
+      token == DYDX_ADDRESS ||
+      token == STAKED_DYDX_ADDRESS,
+      'tokenAddress is not DYDX or stakedDYDX'
+    );
+    IGovernancePowerDelegationERC20(token).delegateByType(delegatee, delegationType);
+  }
+}

--- a/src/migrations/deploy-stark-proxy-v3.ts
+++ b/src/migrations/deploy-stark-proxy-v3.ts
@@ -1,0 +1,84 @@
+import { Interface } from 'ethers/lib/utils';
+
+import {
+  StarkProxyV1__factory,
+  StarkProxyV3,
+  StarkProxyV3__factory,
+} from '../../types';
+import { getDeployerSigner } from '../deploy-config/get-deployer-address';
+import { log } from '../lib/logging';
+import { getRole, waitForTx } from '../lib/util';
+import { Role } from '../types';
+import { deployUpgradeable } from './helpers/deploy-upgradeable';
+
+export async function deployStarkProxyV3({
+  liquidityStakingAddress,
+  merkleDistributorAddress,
+  starkPerpetualAddress,
+  dydxCollateralTokenAddress,
+  ownerRoleAddress,
+}: {
+  liquidityStakingAddress: string,
+  merkleDistributorAddress: string,
+  starkPerpetualAddress: string,
+  dydxCollateralTokenAddress: string,
+  ownerRoleAddress?: string
+}) {
+  log('Beginning Stark Proxy V3 implementation deployment\n');
+  const deployer = await getDeployerSigner();
+  const deployerAddress = deployer.address;
+  log(`Beginning deployment with deployer ${deployerAddress}\n`);
+
+  log('Step 1. Deploy new StarkProxyV1 implementation contract.');
+  const [starkProxyV1, , starkProxyProxyAdmin] = await deployUpgradeable(
+    StarkProxyV1__factory,
+    deployer,
+    [
+      liquidityStakingAddress,
+      starkPerpetualAddress,
+      dydxCollateralTokenAddress,
+      merkleDistributorAddress,
+    ],
+    [deployerAddress],
+  );
+
+  log('Step 2. Deploy new StarkProxyV3 implementation contract.');
+  const starkProxyV3: StarkProxyV3 = await new StarkProxyV3__factory(deployer).deploy(
+    liquidityStakingAddress,
+    starkPerpetualAddress,
+    dydxCollateralTokenAddress,
+    merkleDistributorAddress,
+  );
+  await waitForTx(starkProxyV3.deployTransaction);
+
+  log('Step 3. Upgrade StarkProxyV1 contract with StarkProxyV3 contract.');
+  const initializeCalldata = new Interface(StarkProxyV3__factory.abi).encodeFunctionData(
+    'initialize',
+    [],
+  );
+
+  await waitForTx(
+    await starkProxyProxyAdmin.upgradeAndCall(
+      starkProxyV1.address,
+      starkProxyV3.address,
+      initializeCalldata,
+    ),
+  );
+
+  if (ownerRoleAddress !== undefined) {
+    log(`Step 4. Set OWNER_ROLE to address ${ownerRoleAddress}`);
+    await waitForTx(
+      await starkProxyV1.grantRole(
+        getRole(Role.OWNER_ROLE),
+        ownerRoleAddress,
+      ),
+    );
+  }
+
+  log(`starkProxy contract address: ${starkProxyV1.address}`);
+  log('\n=== NEW STARK PROXY IMPLEMENTATION DEPLOYMENT COMPLETE ===\n');
+
+  return {
+    starkProxyV1WithV3Impl: starkProxyV1,
+  };
+}

--- a/tasks/deployment/stark-proxy-v3.ts
+++ b/tasks/deployment/stark-proxy-v3.ts
@@ -1,0 +1,23 @@
+import { types } from 'hardhat/config';
+
+import mainnetAddresses from '../../src/deployed-addresses/mainnet.json';
+import { hardhatTask } from '../../src/hre';
+import { log } from '../../src/lib/logging';
+import { deployStarkProxyV3 } from '../../src/migrations/deploy-stark-proxy-v3';
+
+hardhatTask('deploy:stark-proxy-v3', 'Deploy the StarkProxyV2 contracts.')
+  .addParam('liquidityStakingAddress', 'Previously deployed liquidity staking address', mainnetAddresses.liquidityStaking, types.string)
+  .addParam('merkleDistributorAddress', 'Previously deployed merkle distributor address', mainnetAddresses.merkleDistributor, types.string)
+  .addParam('starkPerpetualAddress', 'Address of DYDX stark perpetual', mainnetAddresses.starkPerpetual, types.string)
+  .addParam('dydxCollateralTokenAddress', 'Address of collateral token for DYDX stark perpetual', mainnetAddresses.dydxCollateralToken, types.string)
+  .addOptionalParam('ownerRoleAddress', 'Address to give owner role to', undefined, types.string)
+  .setAction(async (args: {
+    liquidityStakingAddress: string,
+    merkleDistributorAddress: string,
+    starkPerpetualAddress: string,
+    dydxCollateralTokenAddress: string,
+    ownerRoleAddress?: string,
+  }) => {
+    const { starkProxyV1WithV3Impl } = await deployStarkProxyV3(args);
+    log(`New StarkProxyV3 implementation deployed to ${starkProxyV1WithV3Impl.address}.`);
+  });

--- a/test/stark-proxy/sp3-owner.spec.ts
+++ b/test/stark-proxy/sp3-owner.spec.ts
@@ -1,0 +1,145 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { expect } from 'chai';
+
+import { getRole } from '../../src/lib/util';
+import { deployStarkProxyV3 } from '../../src/migrations/deploy-stark-proxy-v3';
+import { DelegationType, NetworkName, Role } from '../../src/types';
+import {
+  DydxToken,
+  IStarkPerpetual,
+  LiquidityStakingV1,
+  MerkleDistributorV1,
+  SafetyModuleV1,
+} from '../../types';
+import { StarkProxyV3__factory } from '../../types/factories/StarkProxyV3__factory';
+import { StarkProxyV1 } from '../../types/StarkProxyV1';
+import { StarkProxyV3 } from '../../types/StarkProxyV3';
+import {
+  TestContext,
+  describeContractForNetwork,
+  describeContract,
+} from '../helpers/describe-contract';
+
+
+// Contracts
+let dydxToken: DydxToken;
+let liquidityStaking: LiquidityStakingV1;
+let merkleDistributor: MerkleDistributorV1;
+let safetyModule: SafetyModuleV1;
+let starkPerpetual: IStarkPerpetual;
+let deployer: SignerWithAddress;
+
+let delegateeAddress: string;
+let anotherDelegateeAddress: string;
+
+function init(ctx: TestContext): void {
+  ({
+    dydxToken,
+    liquidityStaking,
+    merkleDistributor,
+    safetyModule,
+    starkPerpetual,
+    deployer,
+  } = ctx);
+  
+  delegateeAddress = ctx.starkProxies[0].address;
+  anotherDelegateeAddress = ctx.starkProxies[1].address;
+}
+
+describeContract('SP3Owner', init, (ctx: TestContext) => {
+  describeContractForNetwork(
+    'SP3Owner Hardhat Tests',
+    ctx,
+    NetworkName.hardhat,
+    true,
+    () => {
+      it('OWNER_ROLE can delegate DYDX and staked DYDX token', async () => {
+        const starkProxyV1WithV3Impl: StarkProxyV1 = (await deployStarkProxyV3({
+          liquidityStakingAddress: liquidityStaking.address,
+          merkleDistributorAddress: merkleDistributor.address,
+          starkPerpetualAddress: starkPerpetual.address,
+          dydxCollateralTokenAddress: dydxToken.address,
+        })).starkProxyV1WithV3Impl;
+        const starkProxyV3: StarkProxyV3 = new StarkProxyV3__factory(deployer).attach(starkProxyV1WithV3Impl.address);
+
+        await Promise.all([
+          starkProxyV3.delegate(
+            dydxToken.address,
+            delegateeAddress,
+          ),
+          starkProxyV3.delegate(
+            safetyModule.address,
+            anotherDelegateeAddress,
+          ),
+        ]);
+
+        expect(
+          await dydxToken.getDelegateeByType(starkProxyV3.address, DelegationType.VOTING_POWER),
+        ).to.equal(delegateeAddress);
+        expect(
+          await dydxToken.getDelegateeByType(starkProxyV3.address, DelegationType.PROPOSITION_POWER),
+        ).to.equal(delegateeAddress);
+
+        expect(
+          await safetyModule.getDelegateeByType(starkProxyV3.address, DelegationType.VOTING_POWER),
+        ).to.equal(anotherDelegateeAddress);
+        expect(
+          await safetyModule.getDelegateeByType(starkProxyV3.address, DelegationType.PROPOSITION_POWER),
+        ).to.equal(anotherDelegateeAddress);
+      });
+
+      it('OWNER_ROLE can delegateByType DYDX and staked DYDX token', async () => {
+        const starkProxyV1WithV3Impl: StarkProxyV1 = (await deployStarkProxyV3({
+          liquidityStakingAddress: liquidityStaking.address,
+          merkleDistributorAddress: merkleDistributor.address,
+          starkPerpetualAddress: starkPerpetual.address,
+          dydxCollateralTokenAddress: dydxToken.address,
+        })).starkProxyV1WithV3Impl;
+        const starkProxyV3: StarkProxyV3 = new StarkProxyV3__factory(deployer).attach(starkProxyV1WithV3Impl.address);
+
+        await Promise.all([
+          starkProxyV3.delegateByType(
+            dydxToken.address,
+            delegateeAddress,
+            DelegationType.VOTING_POWER,
+          ),
+          starkProxyV3.delegateByType(
+            safetyModule.address,
+            anotherDelegateeAddress,
+            DelegationType.PROPOSITION_POWER,
+          ),
+        ]);
+
+        expect(
+          await dydxToken.getDelegateeByType(starkProxyV3.address, DelegationType.VOTING_POWER),
+        ).to.equal(delegateeAddress);
+        expect(
+          await dydxToken.getDelegateeByType(starkProxyV3.address, DelegationType.PROPOSITION_POWER),
+        ).to.equal(starkProxyV3.address);
+
+        expect(
+          await safetyModule.getDelegateeByType(starkProxyV3.address, DelegationType.VOTING_POWER),
+        ).to.equal(starkProxyV3.address);
+        expect(
+          await safetyModule.getDelegateeByType(starkProxyV3.address, DelegationType.PROPOSITION_POWER),
+        ).to.equal(anotherDelegateeAddress);
+      });
+
+      it('OWNER_ROLE can be set to another address', async () => {
+        const starkProxyV1WithV3Impl: StarkProxyV1 = (await deployStarkProxyV3({
+          liquidityStakingAddress: liquidityStaking.address,
+          merkleDistributorAddress: merkleDistributor.address,
+          starkPerpetualAddress: starkPerpetual.address,
+          dydxCollateralTokenAddress: dydxToken.address,
+          ownerRoleAddress: delegateeAddress,
+        })).starkProxyV1WithV3Impl;
+        const starkProxyV3: StarkProxyV3 = new StarkProxyV3__factory(deployer).attach(starkProxyV1WithV3Impl.address);
+
+        const ownerRoleChanged: boolean = await starkProxyV3.hasRole(
+          getRole(Role.OWNER_ROLE),
+          delegateeAddress,
+        );
+        expect(ownerRoleChanged).to.be.true();
+      });
+    });
+});


### PR DESCRIPTION
* `StarkProxyV3` that is identical to `StarkProxyV2` except that it has revision number `3` and inherits from `SP3Owner` instead of `SP2Owner`
  * `SP3Owner` is identical to `SP2Owner` except that it adds the `delegate` and `delegateByType` functions for DYDX token and stakedDYDX token contracts
* Added a script to deploy a `StarkProxyV1` contract, a `StarkProxyV3` contract, and upgrade the `StarkProxyV1` implementation to use the `StarkProxyV3` implementation
  * Additionally, script can update `OWNER_ROLE` if provided as a param